### PR TITLE
Add LinkPython package to requirements.txt

### DIFF
--- a/py-vortex/requirements.txt
+++ b/py-vortex/requirements.txt
@@ -1,5 +1,5 @@
 parsy >= 1.4.0
-#link-python - TODO: fork it and build with link API & python latest
+LinkPython >= 0.1.1
 pyliblo3 >= 0.12.0
 # Mac OSX -> pyliblo3 == 0.11.3
 


### PR DESCRIPTION
I've published the package to [pypi](https://pypi.org/project/LinkPython/), so I've added it to the requirements file.