### PR TITLE
Create SuperDirtStream and LinkClock classes

### DIFF
--- a/py-vortex/py_vortex/stream.py
+++ b/py-vortex/py_vortex/stream.py
@@ -1,5 +1,6 @@
 import math
-import sys
+
+# import sys
 import time
 import threading
 
@@ -9,16 +10,92 @@ import link
 from py_vortex import *
 
 
-class SuperDirtStream:
-    def __init__(self, port=57120, bpm=120):
-        self.port = port
+class LinkClock:
+    def __init__(self, bpm=120):
         self.bpm = bpm
 
-        self.address = liblo.Address(port)
-        self.link = link.Link(bpm)
+        self._subscribers = []
+        self._link = link.Link(bpm)
+        self._play_thread = threading.Thread(target=self._play_thread_target)
+        self._mutex = threading.Lock()
 
-        self.patterns = []
-        self.play_thread = threading.Thread(target=self.play)
+    def subscribe(self, subscriber):
+        with self._mutex:
+            self._subscribers.append(subscriber)
+
+    def unsubscribe(self, subscriber):
+        with self._mutex:
+            self._subscribers.delete(subscriber)
+
+    def play(self):
+        with self._mutex:
+            self._is_playing = True
+        self._play_thread.start()
+
+    def stop(self):
+        with self._mutex:
+            self._is_playing = False
+
+    @property
+    def is_playing(self):
+        return self._is_playing
+
+    def _play_thread_target(self):
+        self._link.enabled = True
+        self._link.startStopSyncEnabled = True
+
+        start = self._link.clock().micros()
+        mill = 1000000
+        start_beat = self._link.captureSessionState().beatAtTime(start, 4)
+        print("start: " + str(start_beat))
+
+        ticks = 0
+
+        # FIXME rate, bpc and latency should be constructor parameters
+        rate = 1 / 20
+        frame = rate * mill
+        bpc = 4
+
+        while self._is_playing:
+            ticks = ticks + 1
+
+            logical_now = math.floor(start + (ticks * frame))
+            logical_next = math.floor(start + ((ticks + 1) * frame))
+
+            now = self._link.clock().micros()
+
+            # wait until start of next frame
+            wait = (logical_now - now) / mill
+            if wait > 0:
+                time.sleep(wait)
+
+            if not self._is_playing:
+                continue
+
+            s = self._link.captureSessionState()
+            cps = (s.tempo() / bpc) / 60
+            cycle_from = s.beatAtTime(logical_now, 0) / bpc
+            cycle_to = s.beatAtTime(logical_next, 0) / bpc
+
+            for sub in self._subscribers:
+                sub.notify_tick((cycle_from, cycle_to), s, cps, bpc, mill, now)
+
+            # sys.stdout.write(
+            #     "cps %.2f | playing %s | cycle %.2f\r"
+            #     % (cps, s.isPlaying(), cycle_from)
+            # )
+
+            # sys.stdout.flush()
+
+
+class SuperDirtStream:
+    def __init__(self, port=57120, latency=0.2):
+        self.pattern = None
+        self.latency = latency
+
+        self._port = port
+        self._address = liblo.Address(port)
+        self._is_playing = True
 
     def play(self):
         self._is_playing = True
@@ -30,79 +107,72 @@ class SuperDirtStream:
     def is_playing(self):
         return self._is_playing
 
-    def __setitem__(self, key, control):
-        self.patterns[key] = control
+    @property
+    def port(self):
+        return self._port
 
-    def __getitem__(self, key):
-        return self.patterns[key]
+    def notify_tick(self, cycle, s, cps, bpc, mill, now):
+        if not self._is_playing or not self.pattern:
+            return
 
-    def _play_thread(self):
-        self.link.enabled = True
-        self.link.startStopSyncEnabled = True
+        cycle_from, cycle_to = cycle
+        es = self.pattern.onsetsOnly().query(TimeSpan(cycle_from, cycle_to))
+        if len(es):
+            print("\n" + str([e.value for e in es]))
 
-        start = self.link.clock().micros()
-        mill = 1000000
-        start_beat = self.link.captureSessionState().beatAtTime(start, 4)
-        print("start: " + str(start_beat))
+        for e in es:
+            cycle_on = e.whole.begin
+            cycle_off = e.whole.end
 
-        ticks = 0
-        # (1/20), bpc and latency should be constructor parameters
-        frame = (1 / 20) * mill
-        bpc = 4
-        latency = 0.2
+            link_on = s.timeAtBeat(cycle_on * bpc, 0)
+            link_off = s.timeAtBeat(cycle_off * bpc, 0)
+            delta_secs = (link_off - link_on) / mill
 
-        while self.is_playing:
-            ticks = ticks + 1
+            # Maybe better to only calc this once??
+            # + it would be better to send link time to supercollider..
+            link_secs = now / mill
+            liblo_diff = liblo.time() - link_secs
+            ts = (link_on / mill) + liblo_diff + self.latency
 
-            logical_now = math.floor(start + (ticks * frame))
-            logical_next = math.floor(start + ((ticks + 1) * frame))
+            # print("liblo time %f link_time %f link_on %f cycle_on %f liblo_diff %f ts %f" % (liblo.time(), link_secs, link_on, cycle_on, liblo_diff, ts))
+            v = e.value
+            v["cps"] = float(cps)
+            v["cycle"] = float(cycle_on)
+            v["delta"] = float(delta_secs)
 
-            # wait until start of next frame
-            wait = (logical_now - self.link.clock().micros()) / mill
-            if wait > 0:
-                time.sleep(wait)
+            msg = []
+            for key, val in v.items():
+                msg.append(key)
+                msg.append(val)
+            print(*msg)
 
-            s = self.link.captureSessionState()
-            cps = (s.tempo() / bpc) / 60
-            cycle_from = s.beatAtTime(logical_now, 0) / bpc
-            cycle_to = s.beatAtTime(logical_next, 0) / bpc
-            es = self.pattern.onsetsOnly().query(TimeSpan(cycle_from, cycle_to))
-            if len(es):
-                print("\n" + str([e.value for e in es]))
+            # liblo.send(superdirt, "/dirt/play", *msg)
+            bundle = liblo.Bundle(ts, liblo.Message("/dirt/play", *msg))
+            liblo.send(self._address, bundle)
 
-            for e in es:
-                cycle_on = e.whole.begin
-                cycle_off = e.whole.end
 
-                link_on = s.timeAtBeat(cycle_on * bpc, 0)
-                link_off = s.timeAtBeat(cycle_off * bpc, 0)
-                delta_secs = (link_off - link_on) / mill
+if __name__ == "__main__":
+    clock = LinkClock(120)
+    clock.play()
 
-                # Maybe better to only calc this once??
-                # + it would be better to send link time to supercollider..
-                link_secs = self.link.clock().micros() / mill
-                liblo_diff = liblo.time() - link_secs
-                ts = (link_on / mill) + liblo_diff + latency
+    stream = SuperDirtStream()
+    clock.subscribe(stream)
 
-                # print("liblo time %f link_time %f link_on %f cycle_on %f liblo_diff %f ts %f" % (liblo.time(), link_secs, link_on, cycle_on, liblo_diff, ts))
-                v = e.value
-                v["cps"] = float(cps)
-                v["cycle"] = float(cycle_on)
-                v["delta"] = float(delta_secs)
+    print("wait a sec")
+    time.sleep(0.5)
 
-                msg = []
-                for key, val in v.items():
-                    msg.append(key)
-                    msg.append(val)
-                print(*msg)
+    print("set pattern")
+    stream.pattern = (
+        s(stack([pure("gabba").fast(pure(4)), pure("cp").fast(pure(3))]))
+        >> speed(sequence([pure(2), pure(3)]))
+        >> room(pure(0.5))
+        >> size(pure(0.8))
+    )
+    time.sleep(3)
 
-                # liblo.send(superdirt, "/dirt/play", *msg)
-                bundle = liblo.Bundle(ts, liblo.Message("/dirt/play", *msg))
-                liblo.send(self.address, bundle)
+    print("unset pattern")
+    stream.pattern = None
+    time.sleep(2)
 
-            sys.stdout.write(
-                "cps %.2f | playing %s | cycle %.2f\r"
-                % (cps, s.isPlaying(), cycle_from)
-            )
-
-            sys.stdout.flush()
+    clock.stop()
+    print("done")

--- a/py-vortex/py_vortex/stream.py
+++ b/py-vortex/py_vortex/stream.py
@@ -20,8 +20,8 @@ class LinkClock:
 
     Parameters
     ----------
-    bpm: Union[float, int]
-        default beats per minute
+    bpm: float
+        beats per minute (default: 120)
 
     """
 

--- a/py-vortex/py_vortex/stream.py
+++ b/py-vortex/py_vortex/stream.py
@@ -1,0 +1,108 @@
+import math
+import sys
+import time
+import threading
+
+import liblo
+import link
+
+from py_vortex import *
+
+
+class SuperDirtStream:
+    def __init__(self, port=57120, bpm=120):
+        self.port = port
+        self.bpm = bpm
+
+        self.address = liblo.Address(port)
+        self.link = link.Link(bpm)
+
+        self.patterns = []
+        self.play_thread = threading.Thread(target=self.play)
+
+    def play(self):
+        self._is_playing = True
+
+    def stop(self):
+        self._is_playing = False
+
+    @property
+    def is_playing(self):
+        return self._is_playing
+
+    def __setitem__(self, key, control):
+        self.patterns[key] = control
+
+    def __getitem__(self, key):
+        return self.patterns[key]
+
+    def _play_thread(self):
+        self.link.enabled = True
+        self.link.startStopSyncEnabled = True
+
+        start = self.link.clock().micros()
+        mill = 1000000
+        start_beat = self.link.captureSessionState().beatAtTime(start, 4)
+        print("start: " + str(start_beat))
+
+        ticks = 0
+        # (1/20), bpc and latency should be constructor parameters
+        frame = (1 / 20) * mill
+        bpc = 4
+        latency = 0.2
+
+        while self.is_playing:
+            ticks = ticks + 1
+
+            logical_now = math.floor(start + (ticks * frame))
+            logical_next = math.floor(start + ((ticks + 1) * frame))
+
+            # wait until start of next frame
+            wait = (logical_now - self.link.clock().micros()) / mill
+            if wait > 0:
+                time.sleep(wait)
+
+            s = self.link.captureSessionState()
+            cps = (s.tempo() / bpc) / 60
+            cycle_from = s.beatAtTime(logical_now, 0) / bpc
+            cycle_to = s.beatAtTime(logical_next, 0) / bpc
+            es = self.pattern.onsetsOnly().query(TimeSpan(cycle_from, cycle_to))
+            if len(es):
+                print("\n" + str([e.value for e in es]))
+
+            for e in es:
+                cycle_on = e.whole.begin
+                cycle_off = e.whole.end
+
+                link_on = s.timeAtBeat(cycle_on * bpc, 0)
+                link_off = s.timeAtBeat(cycle_off * bpc, 0)
+                delta_secs = (link_off - link_on) / mill
+
+                # Maybe better to only calc this once??
+                # + it would be better to send link time to supercollider..
+                link_secs = self.link.clock().micros() / mill
+                liblo_diff = liblo.time() - link_secs
+                ts = (link_on / mill) + liblo_diff + latency
+
+                # print("liblo time %f link_time %f link_on %f cycle_on %f liblo_diff %f ts %f" % (liblo.time(), link_secs, link_on, cycle_on, liblo_diff, ts))
+                v = e.value
+                v["cps"] = float(cps)
+                v["cycle"] = float(cycle_on)
+                v["delta"] = float(delta_secs)
+
+                msg = []
+                for key, val in v.items():
+                    msg.append(key)
+                    msg.append(val)
+                print(*msg)
+
+                # liblo.send(superdirt, "/dirt/play", *msg)
+                bundle = liblo.Bundle(ts, liblo.Message("/dirt/play", *msg))
+                liblo.send(self.address, bundle)
+
+            sys.stdout.write(
+                "cps %.2f | playing %s | cycle %.2f\r"
+                % (cps, s.isPlaying(), cycle_from)
+            )
+
+            sys.stdout.flush()


### PR DESCRIPTION
This PR takes the `play.py` code and refactors it into two classes:
* `LinkClock`, which handles Link synchro
* `SuperDirtStream`, which plays a control pattern and sends the OSC bundles whenever the LinkClock tickes

The idea is that you subscribe a `Stream` instance to a `LinkClock` instance, and if the clock is running, it will call a `notify_tick` method on all subscribed streams. There is a usage example on the `stream.py` file (you can run it directly to test it):

```python
clock = LinkClock(120)
clock.start()

stream = SuperDirtStream()
clock.subscribe(stream)

print(">> Wait a sec")
time.sleep(1)

print(">> Set pattern and let it play for 2 seconds")
stream.pattern = (
    s(stack([pure("gabba").fast(pure(4)), pure("cp").fast(pure(3))]))
    >> speed(sequence([pure(2), pure(3)]))
    >> room(pure(0.5))
    >> size(pure(0.8))
)
time.sleep(2)

print(">> Stop the clock momentarily")
clock.stop()
```