### PR TITLE
Define __eq__ and total ordering on `TimeSpan` and `Event` classes

### DIFF
--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -1,6 +1,6 @@
 
 from decimal import ExtendedContext
-from functools import partial, partialmethod
+from functools import partial, partialmethod, total_ordering
 import sys
 from fractions import Fraction
 from typing import Callable
@@ -16,6 +16,7 @@ Fraction.next_sam = lambda self: self.sam() + 1
 """Returns a TimeSpan representing the begin and end of the Time value's cycle"""
 Fraction.whole_cycle = lambda self: TimeSpan(self.sam(), self.next_sam())
 
+@total_ordering
 class TimeSpan(object):
 
     """ TimeSpan is (Time, Time) """
@@ -86,7 +87,16 @@ class TimeSpan(object):
         return ("(" + show_fraction(self.begin) + ", "
                 +  show_fraction(self.end) + ")")
 
+    def __eq__(self, other) -> bool:
+        if isinstance(other, TimeSpan):
+            return self.begin == other.begin and self.end == other.end
+        return False
 
+    def __le__(self, other) -> bool:
+        return self.begin <= other.begin and self.end <= other.end
+
+
+@total_ordering
 class Event:
 
     """
@@ -125,6 +135,15 @@ class Event:
                 + self.part.__repr__()
                 + ", "
                 + self.value.__repr__() + ")")
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, Event):
+            return self.whole == other.whole and self.part == other.part and self.value == other.value
+        return False
+
+    def __le__(self, other) -> bool:
+        return self.whole <= other.whole and self.part <= other.part and self.value <= other.value
+
 
 class Pattern:
     """

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -426,6 +426,9 @@ class Pattern:
     def __repr__(self):
         return f"Pattern({self.first_cycle()} ...)"
 
+    def __eq__(self, other):
+        raise NotImplementedError("Patterns cannot be compared. Evaluate them with `.first_cycle()` or similar")
+
 
 def pure(value):
     """ Returns a pattern that repeats the given value once per cycle """

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -405,7 +405,8 @@ class Pattern:
         return self.query(TimeSpan(Fraction(0), Fraction(1)))
 
     def __repr__(self):
-        return str(self.first_cycle())
+        return f"Pattern({self.first_cycle()} ...)"
+
 
 def pure(value):
     """ Returns a pattern that repeats the given value once per cycle """


### PR DESCRIPTION
The `__eq__` makes instances of those classes (`Pattern`, `TimeSpan` and `Event`) comparable, making it useful for testing against patterns. It also adds other comparison operators using the `@total_ordering` decorator for `TimeSpan` and `Event`.

This doesn't properly implement `__eq__` for `Pattern`, because it's a composition of functions and I'm not sure how we could do it. It does throw a `NotImplementedError` (instead of a misleading False) if you try to do it, suggesting you evaluate the patterns yourself as a workaround.