### PR TITLE
Random functions 

### DIFF
--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -223,7 +223,7 @@ def test_perlin():
 
 
 def test_perlin_with():
-    assert perlin(saw().fmap(lambda v: v * 4)).segment(2).first_cycle() == [
+    assert perlin(saw() * 4).segment(2).first_cycle() == [
         Event(TimeSpan(0, 1 / 2), TimeSpan(0, 1 / 2), 0.5177721455693245),
         Event(TimeSpan(1 / 2, 1), TimeSpan(1 / 2, 1), 0.8026083502918482),
     ]

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -4,7 +4,9 @@ from vortex.pattern import (
     Fraction,
     TimeSpan,
     fastcat,
+    irand,
     pure,
+    rand,
     rev,
     slowcat,
     stack,
@@ -188,4 +190,22 @@ def test_striate():
             TimeSpan(Fraction(7, 8), Fraction(1, 1)),
             {"s": "sd", "begin": 0.75, "end": 1.0},
         ),
+    ]
+
+
+def test_rand():
+    assert rand.segment(4).first_cycle() == [
+        Event(TimeSpan(0, 1 / 4), TimeSpan(0, 1 / 4), 0.3147844299674034),
+        Event(TimeSpan(1 / 4, 1 / 2), TimeSpan(1 / 4, 1 / 2), 0.6004995740950108),
+        Event(TimeSpan(1 / 2, 3 / 4), TimeSpan(1 / 2, 3 / 4), 0.1394200474023819),
+        Event(TimeSpan(3 / 4, 1), TimeSpan(3 / 4, 1), 0.3935417253524065),
+    ]
+
+
+def test_irand():
+    assert irand(8).segment(4).first_cycle() == [
+        Event(TimeSpan(0, 1 / 4), TimeSpan(0, 1 / 4), 2),
+        Event(TimeSpan(1 / 4, 1 / 2), TimeSpan(1 / 4, 1 / 2), 4),
+        Event(TimeSpan(1 / 2, 3 / 4), TimeSpan(1 / 2, 3 / 4), 1),
+        Event(TimeSpan(3 / 4, 1), TimeSpan(3 / 4, 1), 3),
     ]

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -307,20 +307,20 @@ def test_wchoose_distribution():
 
 def test_degrade():
     assert_equal_patterns(
-        pure("sd").fast(8).degrade(), pure("sd").fast(8).degrade(0.5, rand())
+        pure("sd").fast(8).degrade(), pure("sd").fast(8).degrade_by(0.5, rand())
     )
 
 
 def test_degrade_by():
-    assert pure("sd").fast(8).degrade(0.75).first_cycle() == [
+    assert pure("sd").fast(8).degrade_by(0.75).first_cycle() == [
         Event(TimeSpan(1 / 8, 1 / 4), TimeSpan(1 / 8, 1 / 4), "sd"),
         Event(TimeSpan(1 / 2, 5 / 8), TimeSpan(1 / 2, 5 / 8), "sd"),
         Event(TimeSpan(3 / 4, 7 / 8), TimeSpan(3 / 4, 7 / 8), "sd"),
     ]
 
 
-def test_degrade_by_using():
-    assert pure("sd").fast(8).degrade(0.5, rand().late(100)).first_cycle() == [
+def test_degrade_by_diff_rand():
+    assert pure("sd").fast(8).degrade_by(0.5, rand().late(100)).first_cycle() == [
         Event(TimeSpan(1 / 8, 1 / 4), TimeSpan(1 / 8, 1 / 4), "sd"),
         Event(TimeSpan(3 / 8, 1 / 2), TimeSpan(3 / 8, 1 / 2), "sd"),
         Event(TimeSpan(1 / 2, 5 / 8), TimeSpan(1 / 2, 5 / 8), "sd"),
@@ -329,18 +329,18 @@ def test_degrade_by_using():
 
 def test_undegrade():
     assert_equal_patterns(
-        pure("sd").fast(8).undegrade(), pure("sd").fast(8).undegrade(0.5, rand())
+        pure("sd").fast(8).undegrade(), pure("sd").fast(8).undegrade_by(0.5, rand())
     )
 
 
 def test_undegrade_by():
-    assert pure("sd").fast(8).undegrade(0.25).first_cycle() == [
+    assert pure("sd").fast(8).undegrade_by(0.25).first_cycle() == [
         Event(TimeSpan(0, 1 / 8), TimeSpan(0, 1 / 8), "sd")
     ]
 
 
-def test_undegrade_by_using():
-    assert pure("sd").fast(8).undegrade(0.5, rand().late(100)).first_cycle() == [
+def test_undegrade_by_diff_rand():
+    assert pure("sd").fast(8).undegrade_by(0.5, rand().late(100)).first_cycle() == [
         Event(TimeSpan(0, 1 / 8), TimeSpan(0, 1 / 8), "sd"),
         Event(TimeSpan(1 / 4, 3 / 8), TimeSpan(1 / 4, 3 / 8), "sd"),
         Event(TimeSpan(5 / 8, 3 / 4), TimeSpan(5 / 8, 3 / 4), "sd"),

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -194,7 +194,7 @@ def test_striate():
 
 
 def test_rand():
-    assert rand.segment(4).first_cycle() == [
+    assert rand().segment(4).first_cycle() == [
         Event(TimeSpan(0, 1 / 4), TimeSpan(0, 1 / 4), 0.3147844299674034),
         Event(TimeSpan(1 / 4, 1 / 2), TimeSpan(1 / 4, 1 / 2), 0.6004995740950108),
         Event(TimeSpan(1 / 2, 3 / 4), TimeSpan(1 / 2, 3 / 4), 0.1394200474023819),

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -327,3 +327,25 @@ def test_degrade_by_using():
         Event(TimeSpan(3 / 8, 1 / 2), TimeSpan(3 / 8, 1 / 2), "sd"),
         Event(TimeSpan(1 / 2, 5 / 8), TimeSpan(1 / 2, 5 / 8), "sd"),
     ]
+
+
+def test_undegrade():
+    assert_equal_patterns(
+        pure("sd").fast(8).undegrade(), pure("sd").fast(8).undegrade(0.5, rand())
+    )
+
+
+def test_undegrade_by():
+    assert pure("sd").fast(8).undegrade(0.25).first_cycle() == [
+        Event(TimeSpan(0, 1 / 8), TimeSpan(0, 1 / 8), "sd")
+    ]
+
+
+def test_undegrade_by_using():
+    assert pure("sd").fast(8).undegrade(0.5, rand().late(100)).first_cycle() == [
+        Event(TimeSpan(0, 1 / 8), TimeSpan(0, 1 / 8), "sd"),
+        Event(TimeSpan(1 / 4, 3 / 8), TimeSpan(1 / 4, 3 / 8), "sd"),
+        Event(TimeSpan(5 / 8, 3 / 4), TimeSpan(5 / 8, 3 / 4), "sd"),
+        Event(TimeSpan(3 / 4, 7 / 8), TimeSpan(3 / 4, 7 / 8), "sd"),
+        Event(TimeSpan(7 / 8, 1), TimeSpan(7 / 8, 1), "sd"),
+    ]

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -398,3 +398,37 @@ def test_sometimes_pre_by():
         Event(TimeSpan(0, 1), TimeSpan(3 / 4, 7 / 8), {"s": "bd"}),
         Event(TimeSpan(0, 1), TimeSpan(7 / 8, 1), {"s": "bd"}),
     ]
+
+
+def test_somecycles():
+    assert s("sd").fast(2).somecycles(lambda p: p << speed(3)).query(
+        TimeSpan(0, 4)
+    ) == [
+        Event(TimeSpan(0 / 1, 1 / 2), TimeSpan(0 / 1, 1 / 2), {"speed": 3, "s": "sd"}),
+        Event(TimeSpan(1 / 2, 1 / 1), TimeSpan(1 / 2, 1 / 1), {"speed": 3, "s": "sd"}),
+        Event(TimeSpan(1 / 1, 3 / 2), TimeSpan(1 / 1, 3 / 2), {"s": "sd"}),
+        Event(TimeSpan(3 / 2, 2 / 1), TimeSpan(3 / 2, 2 / 1), {"s": "sd"}),
+        Event(TimeSpan(2 / 1, 5 / 2), TimeSpan(2 / 1, 5 / 2), {"speed": 3, "s": "sd"}),
+        Event(TimeSpan(5 / 2, 3 / 1), TimeSpan(5 / 2, 3 / 1), {"speed": 3, "s": "sd"}),
+        Event(TimeSpan(3 / 1, 7 / 2), TimeSpan(3 / 1, 7 / 2), {"s": "sd"}),
+        Event(TimeSpan(7 / 2, 4 / 1), TimeSpan(7 / 2, 4 / 1), {"s": "sd"}),
+    ]
+
+
+def test_somecycles_by():
+    assert s("sd").fast(2).somecycles_by(0.03, lambda p: p << speed(3)).query(
+        TimeSpan(0, 6)
+    ) == [
+        Event(TimeSpan(0, 1 / 2), TimeSpan(0, 1 / 2), {"speed": 3, "s": "sd"}),
+        Event(TimeSpan(1 / 2, 1), TimeSpan(1 / 2, 1), {"speed": 3, "s": "sd"}),
+        Event(TimeSpan(1, 3 / 2), TimeSpan(1, 3 / 2), {"s": "sd"}),
+        Event(TimeSpan(3 / 2, 2 / 1), TimeSpan(3 / 2, 2 / 1), {"s": "sd"}),
+        Event(TimeSpan(2 / 1, 5 / 2), TimeSpan(2 / 1, 5 / 2), {"s": "sd"}),
+        Event(TimeSpan(5 / 2, 3 / 1), TimeSpan(5 / 2, 3 / 1), {"s": "sd"}),
+        Event(TimeSpan(3 / 1, 7 / 2), TimeSpan(3 / 1, 7 / 2), {"s": "sd"}),
+        Event(TimeSpan(7 / 2, 4 / 1), TimeSpan(7 / 2, 4 / 1), {"s": "sd"}),
+        Event(TimeSpan(4 / 1, 9 / 2), TimeSpan(4 / 1, 9 / 2), {"s": "sd"}),
+        Event(TimeSpan(9 / 2, 5 / 1), TimeSpan(9 / 2, 5 / 1), {"s": "sd"}),
+        Event(TimeSpan(5 / 1, 11 / 2), TimeSpan(5 / 1, 11 / 2), {"s": "sd"}),
+        Event(TimeSpan(11 / 2, 6 / 1), TimeSpan(11 / 2, 6 / 1), {"s": "sd"}),
+    ]

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -106,12 +106,6 @@ def test_reviter():
     )
 
 
-def test_overlay():
-    assert_equal_patterns(
-        pure("bd").fast(2).overlay(pure("sd")), stack(pure("bd").fast(2), pure("sd"))
-    )
-
-
 def test_fastgap():
     assert fastcat(pure("bd"), pure("sd")).fastgap(4).first_cycle() == [
         Event(TimeSpan(0, 1 / 8), TimeSpan(0, 1 / 8), "bd"),

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -1,4 +1,7 @@
+import math
+
 from vortex.control import s
+
 from vortex.pattern import (
     Event,
     Fraction,
@@ -193,6 +196,16 @@ def test_striate():
             {"s": "sd", "begin": 0.75, "end": 1.0},
         ),
     ]
+
+
+def test_range():
+    assert_equal_patterns(saw().range(2, 7), saw() * (7 - 2) + 2)
+
+
+def test_rangex():
+    assert_equal_patterns(
+        saw().rangex(2, 7), saw().range(math.log(2), math.log(7)).fmap(math.exp)
+    )
 
 
 def test_rand():

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -305,3 +305,25 @@ def test_wchoose_distribution():
     # Check recurrence of values based on weights and uniform random distribution
     # a =~ 20, e =~ 10, g =~ 50, c =~ 20
     assert values_groupedby_count == {"a": 22, "e": 10, "g": 48, "c": 20}
+
+
+def test_degrade():
+    assert_equal_patterns(
+        pure("sd").fast(8).degrade(), pure("sd").fast(8).degrade(0.5, rand())
+    )
+
+
+def test_degrade_by():
+    assert pure("sd").fast(8).degrade(0.75).first_cycle() == [
+        Event(TimeSpan(1 / 8, 1 / 4), TimeSpan(1 / 8, 1 / 4), "sd"),
+        Event(TimeSpan(1 / 2, 5 / 8), TimeSpan(1 / 2, 5 / 8), "sd"),
+        Event(TimeSpan(3 / 4, 7 / 8), TimeSpan(3 / 4, 7 / 8), "sd"),
+    ]
+
+
+def test_degrade_by_using():
+    assert pure("sd").fast(8).degrade(0.5, rand().late(100)).first_cycle() == [
+        Event(TimeSpan(1 / 8, 1 / 4), TimeSpan(1 / 8, 1 / 4), "sd"),
+        Event(TimeSpan(3 / 8, 1 / 2), TimeSpan(3 / 8, 1 / 2), "sd"),
+        Event(TimeSpan(1 / 2, 5 / 8), TimeSpan(1 / 2, 5 / 8), "sd"),
+    ]

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -6,6 +6,8 @@ from vortex.pattern import (
     Event,
     Fraction,
     TimeSpan,
+    choose,
+    choose_by,
     fastcat,
     irand,
     perlin,
@@ -239,4 +241,22 @@ def test_perlin_with():
     assert perlin(saw() * 4).segment(2).first_cycle() == [
         Event(TimeSpan(0, 1 / 2), TimeSpan(0, 1 / 2), 0.5177721455693245),
         Event(TimeSpan(1 / 2, 1), TimeSpan(1 / 2, 1), 0.8026083502918482),
+    ]
+
+
+def test_choose_by():
+    assert choose_by(perlin(), *range(8)).segment(4).first_cycle() == [
+        Event(TimeSpan(0, 1 / 4), TimeSpan(0, 1 / 4), 0),
+        Event(TimeSpan(1 / 4, 1 / 2), TimeSpan(1 / 4, 1 / 2), 1),
+        Event(TimeSpan(1 / 2, 3 / 4), TimeSpan(1 / 2, 3 / 4), 3),
+        Event(TimeSpan(3 / 4, 1), TimeSpan(3 / 4, 1), 4),
+    ]
+
+
+def test_choose():
+    assert choose("a", "b", "c").segment(4).first_cycle() == [
+        Event(TimeSpan(0, 1 / 4), TimeSpan(0, 1 / 4), "a"),
+        Event(TimeSpan(1 / 4, 1 / 2), TimeSpan(1 / 4, 1 / 2), "b"),
+        Event(TimeSpan(1 / 2, 3 / 4), TimeSpan(1 / 2, 3 / 4), "a"),
+        Event(TimeSpan(3 / 4, 1), TimeSpan(3 / 4, 1), "b"),
     ]

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -5,9 +5,11 @@ from vortex.pattern import (
     TimeSpan,
     fastcat,
     irand,
+    perlin,
     pure,
     rand,
     rev,
+    saw,
     slowcat,
     stack,
     timecat,
@@ -208,4 +210,20 @@ def test_irand():
         Event(TimeSpan(1 / 4, 1 / 2), TimeSpan(1 / 4, 1 / 2), 4),
         Event(TimeSpan(1 / 2, 3 / 4), TimeSpan(1 / 2, 3 / 4), 1),
         Event(TimeSpan(3 / 4, 1), TimeSpan(3 / 4, 1), 3),
+    ]
+
+
+def test_perlin():
+    assert perlin().segment(4).first_cycle() == [
+        Event(TimeSpan(0, 1 / 4), TimeSpan(0, 1 / 4), 0.008311405901167745),
+        Event(TimeSpan(1 / 4, 1 / 2), TimeSpan(1 / 4, 1 / 2), 0.1424947878645071),
+        Event(TimeSpan(1 / 2, 3 / 4), TimeSpan(1 / 2, 3 / 4), 0.3752773577048174),
+        Event(TimeSpan(3 / 4, 1), TimeSpan(3 / 4, 1), 0.5094607396681567),
+    ]
+
+
+def test_perlin_with():
+    assert perlin(saw().fmap(lambda v: v * 4)).segment(2).first_cycle() == [
+        Event(TimeSpan(0, 1 / 2), TimeSpan(0, 1 / 2), 0.5177721455693245),
+        Event(TimeSpan(1 / 2, 1), TimeSpan(1 / 2, 1), 0.8026083502918482),
     ]

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -4,10 +4,9 @@ from itertools import groupby
 from vortex.control import s, speed
 from vortex.pattern import (
     Event,
-    Fraction,
     TimeSpan,
     choose,
-    chooseby,
+    choose_by,
     fast,
     fastcat,
     irand,
@@ -20,7 +19,7 @@ from vortex.pattern import (
     stack,
     timecat,
     wchoose,
-    wchooseby,
+    wchoose_by,
 )
 
 
@@ -255,7 +254,7 @@ def test_choose():
 
 
 def test_chooseby():
-    assert chooseby(perlin(), *range(8)).segment(4).first_cycle() == [
+    assert choose_by(perlin(), *range(8)).segment(4).first_cycle() == [
         Event(TimeSpan(0, 1 / 4), TimeSpan(0, 1 / 4), 0),
         Event(TimeSpan(1 / 4, 1 / 2), TimeSpan(1 / 4, 1 / 2), 1),
         Event(TimeSpan(1 / 2, 3 / 4), TimeSpan(1 / 2, 3 / 4), 3),
@@ -282,7 +281,7 @@ def test_wchoose():
 
 
 def test_wchooseby():
-    assert wchooseby(
+    assert wchoose_by(
         rand().late(100), ("a", 1), ("e", 0.5), ("g", 2), ("c", 1)
     ).segment(4).first_cycle() == [
         Event(TimeSpan(0, 1 / 4), TimeSpan(0, 1 / 4), "a"),

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -145,8 +145,14 @@ class Event:
 
     def __le__(self, other) -> bool:
         return (
-            self.whole <= other.whole
+            self.whole
+            and other.whole
+            and self.whole <= other.whole
+            and self.part
+            and other.part
             and self.part <= other.part
+            and self.value
+            and other.value
             and self.value <= other.value
         )
 

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -666,8 +666,8 @@ class Pattern:
         """
         Randomly removes events from pattern.
 
-        By default, chance is 50% (0.5). You can control control the percentage
-        of events that are removed with `val`. With `prand` you can specify a
+        By default, chance is 50% (0.5). You can control the percentage of
+        events that are removed with `val`. With `prand` you can specify a
         different random pattern, must be a numerical 0-1 ranged pattern.
 
         """
@@ -675,6 +675,19 @@ class Pattern:
             prand = rand()
         return self.fmap(lambda a: lambda _: a).app_left(
             prand._filter_values(lambda v: v > val)
+        )
+
+    def undegrade(self, val=0.5, prand=None):
+        """
+        Same as `degrade` but with the percentage describing how many events to
+        keep on average, not remove.
+
+        """
+        if not prand:
+            prand = rand()
+        # return self.degrade(val, prand.fmap(lambda r: 1 - r))
+        return self.fmap(lambda a: lambda _: a).app_left(
+            prand._filter_values(lambda v: v <= val)
         )
 
     def __repr__(self):

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -1080,7 +1080,7 @@ def timecat(*time_pat_tuples):
     )
 
 
-def chooseby(pat, *vals):
+def choose_by(pat, *vals):
     """
     Randomly picks an element from the given list
 
@@ -1091,10 +1091,10 @@ def chooseby(pat, *vals):
 
 def choose(*vals):
     """Randomly picks an element from the given list"""
-    return chooseby(rand(), *vals)
+    return choose_by(rand(), *vals)
 
 
-def wchooseby(pat, *pairs):
+def wchoose_by(pat, *pairs):
     """
     Like @choose@, but works on an a list of tuples of values and weights
 
@@ -1118,4 +1118,4 @@ def wchooseby(pat, *pairs):
 
 def wchoose(*vals):
     """Like @choose@, but works on an a list of tuples of values and weights"""
-    return wchooseby(rand(), *vals)
+    return wchoose_by(rand(), *vals)

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -152,9 +152,6 @@ class Event:
             and self.part
             and other.part
             and self.part <= other.part
-            and self.value
-            and other.value
-            and self.value <= other.value
         )
 
 

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -565,10 +565,6 @@ class Pattern:
         """
         return slowcat(*[self.late(Fraction(i, n)) for i in range(n)])
 
-    def overlay(self, pat):
-        """Combine itself with another pattern"""
-        return Pattern(lambda span: concat([self.query(span), pat.query(span)]))
-
     def compress(self, begin, end):
         """Squeeze pattern within the specified time span"""
         begin = Fraction(begin)
@@ -729,7 +725,7 @@ class Pattern:
         return reify(by_pat).fmap(lambda by: self._sometimes_by(by, func)).inner_join()
 
     def _sometimes_by(self, by, func):
-        return self.degrade_by(by).overlay(func(self.undegrade_by(by)))
+        return stack(self.degrade_by(by), func(self.undegrade_by(by)))
 
     def sometimes_pre(self, func):
         """
@@ -753,7 +749,7 @@ class Pattern:
         )
 
     def _sometimes_pre_by(self, by, func):
-        return self.degrade_by(by).overlay(func(self).undegrade_by(by))
+        return stack(self.degrade_by(by), func(self).undegrade_by(by))
 
     def __repr__(self):
         events = [str(e) for e in self.first_cycle()]

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -757,10 +757,13 @@ def reify(x):
 
 
 # Randomness
+RANDOM_CONSTANT = 2**29
+RANDOM_CYCLES_LENGTH = 300
 
 
 def xorwise(x: int) -> int:
-    """Xorshift RNG
+    """
+    Xorshift RNG
 
     cf. George Marsaglia (2003). "Xorshift RNGs". Journal of Statistical Software 8:14.
     https://www.jstatsoft.org/article/view/v008i14
@@ -771,12 +774,17 @@ def xorwise(x: int) -> int:
     return (b << 5) ^ b
 
 
-def time_to_int_seed(a: float | Fraction) -> int:
-    return xorwise(math.trunc((a / 300) * 536870912))
+def time_to_int_seed(a: float) -> int:
+    """
+    Stretch RANDOM_CYCLES_LENGTH cycles over the range of [0, RANDOM_CONSTANT)
+    then apply the xorshift algorithm.
+
+    """
+    return xorwise(math.trunc((a / RANDOM_CYCLES_LENGTH) * RANDOM_CONSTANT))
 
 
-def int_seed_to_rand(a: int) -> Fraction:
-    return (a % 536870912) / 536870912
+def int_seed_to_rand(a: int) -> float:
+    return (a % RANDOM_CONSTANT) / RANDOM_CONSTANT
 
 
 def time_to_rand(a):

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -240,20 +240,19 @@ class Pattern:
         resolve wholes, applies a given pattern of values to that
         pattern of functions.
         """
-        pat_func = self
 
         def query(span):
-            event_funcs = pat_func.query(span)
+            event_funcs = self.query(span)
             event_vals = pat_val.query(span)
 
-            def apply(event_funcs, event_vals):
-                s = event_funcs.part.intersection(event_vals.part)
+            def apply(event_func, event_val):
+                s = event_func.part.intersection(event_val.part)
                 if s == None:
                     return None
                 return Event(
-                    whole_func(event_funcs.whole, event_vals.whole),
+                    whole_func(event_func.whole, event_val.whole),
                     s,
-                    event_funcs.value(event_vals.value),
+                    event_func.value(event_val.value),
                 )
 
             return concat(
@@ -271,10 +270,10 @@ class Pattern:
     def app_both(self, pat_val):
         """Tidal's <*>"""
 
-        def whole_func(span_a, span_B):
-            if span_a == None or span_B == None:
+        def whole_func(span_a, span_b):
+            if span_a == None or span_b == None:
                 return None
-            return span_a.intersection_e(span_B)
+            return span_a.intersection_e(span_b)
 
         return self._app_whole(whole_func, pat_val)
 

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -641,6 +641,26 @@ class Pattern:
         """
         return pure(id).fast(n).app_left(self)
 
+    def range(self, min, max):
+        """
+        Rescales values to the range [min, max]
+
+        Assumes pattern is numerical, containing unipolar values in the range
+        [0, 1].
+
+        """
+        return self * (max - min) + min
+
+    def rangex(self, min, max):
+        """
+        Rescales values to the range [min, max] following an exponential curve
+
+        Assumes pattern is numerical, containing unipolar values in the range
+        [0, 1].
+
+        """
+        return self.range(math.log(min), math.log(max)).fmap(math.exp)
+
     def __repr__(self):
         events = [str(e) for e in self.first_cycle()]
         events_str = ",\n ".join(events).replace("\n", "\n ")

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -832,8 +832,8 @@ def signal(func):
 sine2 = lambda: signal(lambda t: math.sin(math.pi * 2 * t))
 sine = lambda: signal(lambda t: (math.sin(math.pi * 2 * t) + 1) / 2)
 
-cosine2 = sine2().early(0.25)
-cosine = sine().early(0.25)
+cosine2 = lambda: sine2().early(0.25)
+cosine = lambda: sine().early(0.25)
 
 saw2 = lambda: signal(lambda t: (t % 1) * 2)
 saw = lambda: signal(lambda t: t % 1)
@@ -841,8 +841,8 @@ saw = lambda: signal(lambda t: t % 1)
 isaw2 = lambda: signal(lambda t: (1 - (t % 1)) * 2)
 isaw = lambda: signal(lambda t: 1 - (t % 1))
 
-tri2 = fastcat(isaw2(), saw2())
-tri = fastcat(isaw(), saw())
+tri2 = lambda: fastcat(isaw2(), saw2())
+tri = lambda: fastcat(isaw(), saw())
 
 square2 = lambda: signal(lambda t: (math.floor((t * 2) % 2) * 2) - 1)
 square = lambda: signal(lambda t: math.floor((t * 2) % 2))

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -659,32 +659,50 @@ class Pattern:
         """
         return self.range(math.log(min), math.log(max)).fmap(math.exp)
 
-    def degrade(self, val=0.5, prand=None):
+    def degrade(self):
+        """
+        Randomly removes events from pattern, by 50% chance.
+
+        """
+        return self.degrade_by(0.5)
+
+    def degrade_by(self, by, prand=None):
         """
         Randomly removes events from pattern.
 
-        By default, chance is 50% (0.5). You can control the percentage of
-        events that are removed with `val`. With `prand` you can specify a
-        different random pattern, must be a numerical 0-1 ranged pattern.
+        You can control the percentage of events that are removed with `by`.
+        With `prand` you can specify a different random pattern, must be a
+        numerical 0-1 ranged pattern.
 
         """
         if not prand:
             prand = rand()
         return self.fmap(lambda a: lambda _: a).app_left(
-            prand._filter_values(lambda v: v > val)
+            prand._filter_values(lambda v: v > by)
         )
 
-    def undegrade(self, val=0.5, prand=None):
+    def undegrade(self):
         """
-        Same as `degrade` but with the percentage describing how many events to
-        keep on average, not remove.
+        Same as `degrade`, but random values represent percentage of events to
+        keep, not remove, by 50% chance.
+
+        """
+        return self.undegrade_by(0.5)
+
+    def undegrade_by(self, by, prand=None):
+        """
+        Same as `degrade`, but random values represent percentage of events to
+        keep, not remove.
+
+        You can control the percentage of events that are removed with `by`.
+        With `prand` you can specify a different random pattern, must be a
+        numerical 0-1 ranged pattern.
 
         """
         if not prand:
             prand = rand()
-        # return self.degrade(val, prand.fmap(lambda r: 1 - r))
         return self.fmap(lambda a: lambda _: a).app_left(
-            prand._filter_values(lambda v: v <= val)
+            prand._filter_values(lambda v: v <= by)
         )
 
     def sometimes(self, func):
@@ -711,7 +729,7 @@ class Pattern:
         return reify(by_pat).fmap(lambda by: self._sometimes_by(by, func)).inner_join()
 
     def _sometimes_by(self, by, func):
-        return self.degrade(by).overlay(func(self.undegrade(by)))
+        return self.degrade_by(by).overlay(func(self.undegrade_by(by)))
 
     def sometimes_pre(self, func):
         """
@@ -735,7 +753,7 @@ class Pattern:
         )
 
     def _sometimes_pre_by(self, by, func):
-        return self.degrade(by).overlay(func(self).undegrade(by))
+        return self.degrade_by(by).overlay(func(self).undegrade_by(by))
 
     def __repr__(self):
         events = [str(e) for e in self.first_cycle()]

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -984,3 +984,13 @@ def timecat(*time_pat_tuples):
             for s, e, pat in arranged
         ]
     )
+
+
+def choose_by(pat, *vals):
+    """Randomly picks an element from the given list, based on a 0-1 ranged numerical pattern"""
+    return pat.range(0, len(vals)).fmap(lambda v: vals[math.floor(v)])
+
+
+def choose(*vals):
+    """Randomly picks an element from the given list"""
+    return choose_by(rand(), *vals)

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -690,6 +690,56 @@ class Pattern:
             prand._filter_values(lambda v: v <= val)
         )
 
+    def sometimes(self, func):
+        """
+        Applies a function to pattern, around 50% of the time, at
+        random.
+
+        >>> s("bd").fast(8).sometimes(lambda p: p << speed(2))
+
+        """
+        return self.sometimes_by(0.5, func)
+
+    def sometimes_by(self, by_pat, func):
+        """
+        Applies a function to pattern sometimes based on specified `by`
+        percentage, at random.
+
+        `by` is a number between 0 and 1, representing 0% to 100% chance of
+        applying function.
+
+        >>> s("bd").fast(8).sometimes_by(0.75, lambda p: p << speed(3))
+
+        """
+        return reify(by_pat).fmap(lambda by: self._sometimes_by(by, func)).inner_join()
+
+    def _sometimes_by(self, by, func):
+        return self.degrade(by).overlay(func(self.undegrade(by)))
+
+    def sometimes_pre(self, func):
+        """
+        Similar to `sometimes` but applies a function to the pattern *before*
+        filtering events 50% of the time, at random.
+
+        """
+        return self.sometimes_pre_by(0.5, func)
+
+    def sometimes_pre_by(self, by_pat, func):
+        """
+        Similar to `sometimes_by` but applies a function to the pattern *before*
+        filtering events sometimes, based on `by` percentage, at random.
+
+        `by` is a number between 0 and 1, representing 0% to 100% chance of
+        applying function.
+
+        """
+        return (
+            reify(by_pat).fmap(lambda by: self._sometimes_pre_by(by, func)).inner_join()
+        )
+
+    def _sometimes_pre_by(self, by, func):
+        return self.degrade(by).overlay(func(self).undegrade(by))
+
     def __repr__(self):
         events = [str(e) for e in self.first_cycle()]
         events_str = ",\n ".join(events).replace("\n", "\n ")

--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -662,6 +662,21 @@ class Pattern:
         """
         return self.range(math.log(min), math.log(max)).fmap(math.exp)
 
+    def degrade(self, val=0.5, prand=None):
+        """
+        Randomly removes events from pattern.
+
+        By default, chance is 50% (0.5). You can control control the percentage
+        of events that are removed with `val`. With `prand` you can specify a
+        different random pattern, must be a numerical 0-1 ranged pattern.
+
+        """
+        if not prand:
+            prand = rand()
+        return self.fmap(lambda a: lambda _: a).app_left(
+            prand._filter_values(lambda v: v > val)
+        )
+
     def __repr__(self):
         events = [str(e) for e in self.first_cycle()]
         events_str = ",\n ".join(events).replace("\n", "\n ")


### PR DESCRIPTION
This PR implements the following functions related to randomness:

- [x] `rand`
- [x] `irand`
- [x] `perlin`
- [x] `choose` / `choose_by`
- [x] `wchoose` / `wchoose_by`
- [x] `degrade` / `degrade_by`
- [x] `undegrade` / `undegrade_by`
- [x] `sometimes` / `sometimes_by`
- [x] `somecycles` / `somecycles_by`

And brings the following changes:

* Define `when_cycle`, which is the same implementaiton of `when` from Tidal. In Vortex, `when` uses a boolean pattern to test whether to apply a given transformation function, but `when_cycle` uses a test function for the cycle number, and applies the function to each cycle.
* Make all signals functions, not variables (`rand` -> `rand()`, `sine` -> `sine()`), this allows us to add docstrings to them and makes it more consistent with other functions that return patterns (like `irand(n)`).
* Defines `range` and `rangex`.
* Remove `overlay`, superseeded by `stack`.
* Some fixes to `__le__` on `Event`