### PR TITLE
feat: Minify all string arguments when reifying

### DIFF
--- a/vortex/pattern.py
+++ b/vortex/pattern.py
@@ -900,6 +900,8 @@ def stack(*pats):
 
 
 def _sequence_count(x):
+    from .mini import mini
+
     if type(x) == list or type(x) == tuple:
         if len(x) == 1:
             return _sequence_count(x[0])
@@ -907,8 +909,9 @@ def _sequence_count(x):
             return (fastcat(*[sequence(x) for x in x]), len(x))
     if isinstance(x, Pattern):
         return (x, 1)
-    else:
-        return (pure(x), 1)
+    if isinstance(x, str):
+        return (mini(x), 1)
+    return (pure(x), 1)
 
 
 def sequence(*args):
@@ -949,8 +952,12 @@ def polyrhythm(*xs):
 pr = polyrhythm
 
 
-def reify(x):
+def reify(x) -> Pattern:
+    from .mini import mini
+
     if not isinstance(x, Pattern):
+        if isinstance(x, str):
+            return mini(x)
         return pure(x)
     return x
 


### PR DESCRIPTION
```python
In [1]: s("bd sd")
Out[1]: 
~[((0, ½), (0, ½), {'s': 'bd'}),
  ((½, 1), (½, 1), {'s': 'sd'})] ...~

In [2]: s("bd").fast("2 4")
Out[2]: 
~[((0, ½), (0, ½), {'s': 'bd'}),
  ((½, ¾), (½, ¾), {'s': 'bd'}),
  ((¾, 1), (¾, 1), {'s': 'bd'})] ...~
```

To express raw strings and skip mininotation parsing, one can use `pure`:

```python
In [2]: s(pure("bd sd"))
Out[2]: ~[((0, 1), (0, 1), {'s': 'bd sd'})] ...~
```