### PR TITLE
refactor: Aliases `combine_left` and `combine_right` with support for lists of patterns + `Stream` refactor

### DIFF
--- a/vortex/boot.py
+++ b/vortex/boot.py
@@ -5,11 +5,13 @@ _default_clock = LinkClock(bpm=120)
 _streams = {}
 
 
-def p(key):
+def p(key, pattern=None):
     if key not in _streams:
         stream = SuperDirtStream(name=key)
         _default_clock.subscribe(stream)
         _streams[key] = stream
+    if pattern:
+        _streams[key].pattern = pattern
     return _streams[key]
 
 

--- a/vortex/boot.py
+++ b/vortex/boot.py
@@ -5,13 +5,12 @@ _default_clock = LinkClock(bpm=120)
 _streams = {}
 
 
-def p(key, pattern):
+def p(key):
     if key not in _streams:
-        stream = SuperDirtStream()
+        stream = SuperDirtStream(name=key)
         _default_clock.subscribe(stream)
         _streams[key] = stream
-    _streams[key].pattern = pattern
-    return pattern
+    return _streams[key]
 
 
 def hush():

--- a/vortex/gui.py
+++ b/vortex/gui.py
@@ -27,8 +27,8 @@ DEFAULT_CODE = r"""# this is an example code
 # another block
 #
 
-p("test", s(stack(pure("gabba").fast(4), pure("cp").fast(3))).every(3, fast(2))
-    >> speed(sequence(2, 3))
+p("test", s(stack("gabba*4", "cp*3").every(3, fast(2)))
+    >> speed("2 3")
     >> room(0.5)
     >> size(0.8)
 )

--- a/vortex/stream.py
+++ b/vortex/stream.py
@@ -143,7 +143,8 @@ class SuperDirtStream:
 
     """
 
-    def __init__(self, port=57120, latency=0.2):
+    def __init__(self, port=57120, latency=0.2, name=None):
+        self.name = name
         self.pattern = None
         self.latency = latency
 
@@ -210,6 +211,23 @@ class SuperDirtStream:
             # liblo.send(superdirt, "/dirt/play", *msg)
             bundle = liblo.Bundle(ts, liblo.Message("/dirt/play", *msg))
             liblo.send(self._address, bundle)
+
+    def set(self, pattern):
+        self.pattern = pattern
+        return self
+
+    def __lshift__(self, new_pattern):
+        if self.pattern:
+            return self.set(self.pattern << new_pattern)
+        return self.set(new_pattern)
+
+    def __rshift__(self, new_pattern):
+        if self.pattern:
+            return self.set(self.pattern >> new_pattern)
+        return self.set(new_pattern)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {repr(self.name)}>"
 
 
 if __name__ == "__main__":

--- a/vortex/stream.py
+++ b/vortex/stream.py
@@ -227,7 +227,8 @@ class SuperDirtStream:
         return self.set(new_pattern)
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} {repr(self.name)}>"
+        pattern_repr = " \n" + repr(self.pattern) if self.pattern else ""
+        return f"<{self.__class__.__name__} {repr(self.name)}{pattern_repr} at {hash(self)}>"
 
 
 if __name__ == "__main__":

--- a/vortex/stream.py
+++ b/vortex/stream.py
@@ -199,9 +199,7 @@ class BaseStream(ABC):
 
 class SuperDirtStream(BaseStream):
     """
-    A class for sending control pattern messages to SuperDirt
-
-    It should be subscribed to a LinkClock instance.
+    This Stream class sends control pattern messages to SuperDirt via OSC
 
     Parameters
     ----------


### PR DESCRIPTION
* Define the aliases `combine_left` and `combine_right` for `<<` and `>>` respectively on `Pattern`
* Make `<<` and `>>` support multiple `Pattern` arguments, which folds the pattern combination in the corresponding order. The operator aliases (`combine_left` and `combine_right`) support combining an iterable of patterns as well.
* Split `SuperDirtStream` basic implementation into a BaseStream` abstract class
* Includes the currently assigned pattern repr on `Stream.__repr__`

I also tried to explore using `<<` and `>>` on stream objects, to set patterns and avoid adding extra parenthesis, but this caused issues and was discarded. These binary operators are left associative, and for this to work properly it should be right associative, but operator associativity and precedence cannot be changed in Python (it's hardcoded in its parser) unless we implement a way to lazily combine patterns and store these combination expressions, and then evaluate these expressions in the preferred order when assigned to a Stream.